### PR TITLE
Settings: bring back old style mobile data indicators

### DIFF
--- a/res/values/fuse_strings.xml
+++ b/res/values/fuse_strings.xml
@@ -259,4 +259,8 @@
     <!-- General -->
     <string name="copied_to_clipboard">Copied to clipboard</string>
     <string name="longpress_to_clipboard">Long-press to copy</string>
+
+    <!-- Old mobile type icons -->
+    <string name="use_old_mobiletype_title">Small mobile type icon</string>
+    <string name="use_old_mobiletype_summary">Show mobile type icon on top of the signal indicator</string>
 </resources>

--- a/res/xml/display_customizations.xml
+++ b/res/xml/display_customizations.xml
@@ -44,6 +44,12 @@
             android:summary="@string/combined_status_bar_signal_icons_summary"
             android:defaultValue="false" />
 
+        <com.fusion.support.preferences.SystemSettingSwitchPreference
+            android:key="use_old_mobiletype"
+            android:title="@string/use_old_mobiletype_title"
+            android:summary="@string/use_old_mobiletype_summary"
+            android:defaultValue="true" />
+            
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Change-Id: Iff218eee7425964bca53d7dd2d6da0ffdb3a7c69